### PR TITLE
Keep item queue number after filter

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-and-publish-docs:

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -75,7 +75,7 @@
 							href={base + pkg_url_full(sub)}
 							class="flex flex-row space-x-1 items-center hover:bg-slate-200 odd:bg-white even:bg-slate-50 px-2 py-1 first:rounded-t-md last:rounded-b-md"
 						>
-							<div class="font-light text-sm w-14 text-slate-500">#{idx_sub + 1}</div>
+							<div class="font-light text-sm w-14 text-slate-500">#{sub.original_position ?? (idx_sub + 1)}</div>
 							<div class="text-slate-900">
 								{sub.pkg_name}
 							</div>

--- a/src/server_data.ts
+++ b/src/server_data.ts
@@ -197,7 +197,9 @@ export class SubmissionRepo {
         const str_lower = str.toLowerCase();
         re.queues = this.queues.map((qu) => ({
             info: qu.info,
-            queue: qu.queue.filter((sub) => sub.pkg_name.toLowerCase().search(str_lower) > -1)
+            queue: qu.queue
+                .map((sub, idx) => ({ ...sub, original_position: sub.original_position ?? idx + 1 }))
+                .filter((sub) => sub.pkg_name.toLowerCase().search(str_lower) > -1)
         })).filter((qu) => qu.queue.length > 0);
         return re;
     }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -14,6 +14,7 @@ interface Submission {
     pkg_name: string;
     pkg_version: string;
     request_time: string;
+    original_position?: number;
 }
 interface Snapshot {
     capture_duration: number;


### PR DESCRIPTION
Implements #6 .

This pull request updates how submission positions are tracked and displayed in the queue, ensuring that each submission retains its original position even after filtering or mapping. The most important changes are:

**Submission position tracking and display:**

* In `src/server_data.ts`, the queue mapping now adds an `original_position` property to each submission, defaulting to its index if not already set. This preserves the original order information for each item.
* In `src/routes/+page.svelte`, the display logic for submission position now uses `sub.original_position` if available, falling back to the calculated index. This ensures consistent position display after queue filtering.